### PR TITLE
fix to ThreadSafeBus arg names

### DIFF
--- a/piper_sdk/hardware_port/can_encapsulation.py
+++ b/piper_sdk/hardware_port/can_encapsulation.py
@@ -77,7 +77,7 @@ class C_STD_CAN():
         if self.bus is not None:
             return
         try:
-            self.bus = can.ThreadSafeBus(channel=self.channel_name, bustype=self.bustype)
+            self.bus = can.ThreadSafeBus(channel=self.channel_name, interface=self.bustype)
             print(self.channel_name,"bus opened successfully.")
         except can.CanError as e:
             print(f"Failed to open CAN bus: {e}")

--- a/piper_sdk/hardware_port/can_encapsulation_v0_4_0.py
+++ b/piper_sdk/hardware_port/can_encapsulation_v0_4_0.py
@@ -115,7 +115,7 @@ class C_STD_CAN():
             # return True
             return self.CAN_STATUS.INIT_CAN_BUS_IS_EXIST
         try:
-            self.bus = can.ThreadSafeBus(channel=self.channel_name, bustype=self.bustype)
+            self.bus = can.ThreadSafeBus(channel=self.channel_name, interface=self.bustype)
             return self.CAN_STATUS.INIT_CAN_BUS_OPENED_SUCCESS
         except can.CanError as e:
             self.bus = None


### PR DESCRIPTION
the argnames for ThreadSafeBus are wrong now (deprecated?), just a small fix to make it work again.